### PR TITLE
Convert new address to old address

### DIFF
--- a/vietnamadminunits/__init__.py
+++ b/vietnamadminunits/__init__.py
@@ -1,2 +1,2 @@
 from .parser import parse_address, ParseMode
-from .converter import convert_address, ConvertMode
+from .converter import convert_address, convert_address_to_old, ConvertMode

--- a/vietnamadminunits/converter/__init__.py
+++ b/vietnamadminunits/converter/__init__.py
@@ -1,10 +1,11 @@
-from .converter_2025 import convert_address_2025
+from .converter_2025 import convert_address_2025, convert_address_to_old_2025
 from enum import Enum
 from typing import Union
 
 
 class ConvertMode(Enum):
     CONVERT_2025 = "CONVERT_2025"  # From LEGACY → MERGER_2025
+    CONVERT_TO_OLD_2025 = "CONVERT_TO_OLD_2025"  # From MERGER_2025 → LEGACY
 
     @classmethod
     def available(cls, value=False):
@@ -25,5 +26,20 @@ def convert_address(address: str, mode: Union[str, ConvertMode]=ConvertMode.CONV
 
     if mode in [ConvertMode.CONVERT_2025, ConvertMode.CONVERT_2025.value]:
         return convert_address_2025(address)
+    else:
+        raise Exception(f"Invalid mode. Available modes are {ConvertMode.available(value=True)}.")
+
+
+def convert_address_to_old(address: str, mode: Union[str, ConvertMode]=ConvertMode.CONVERT_TO_OLD_2025):
+    '''
+    Converts an address from the 34-province format to the old 63-province format `AdminUnit`.
+
+    :param address: Best format *"(street), ward, province"*. Case is ignored, accents are usually ignored except in rare cases.
+    :param mode: Currently, only `'CONVERT_TO_OLD_2025'` is supported.
+    :return: AdminUnit object.
+    '''
+
+    if mode in [ConvertMode.CONVERT_TO_OLD_2025, ConvertMode.CONVERT_TO_OLD_2025.value]:
+        return convert_address_to_old_2025(address)
     else:
         raise Exception(f"Invalid mode. Available modes are {ConvertMode.available(value=True)}.")

--- a/vietnamadminunits/converter/converter_2025.py
+++ b/vietnamadminunits/converter/converter_2025.py
@@ -109,3 +109,110 @@ def convert_address_2025(address: str):
     new_unit.OldAdminUnit = old_unit
 
     return new_unit
+
+
+# REVERSE CONVERSION FUNCTION
+def convert_address_to_old_2025(address: str):
+    '''
+    Convert address from new format (34-province) to old format (63-province) based on the Vietnam administrative unit changes in 2025
+    :param address: str - The new address to convert
+
+    :return: AdminUnit object
+    '''
+
+    old_ward_key = None
+    old_district_key = None
+
+    # Parse địa chỉ mới trước
+    new_unit = parse_address(address, mode=ParseMode.FROM_2025, keep_street=True, level=2)
+
+    # Suy province_key mới ra province_key cũ
+    # DICT_PROVINCE maps: {new_province_key: [list of old_province_keys]}
+    old_province_key = None
+    old_province_district_ward_key = None
+
+    # Tạo old_province_district_ward_key từ ward_key mới
+    if new_unit.ward_key and new_unit.province_key:
+        
+        # 1st attempt: Suy từ new_ward_key ra old_province_district_ward_key, phần lớn các ward cũ không bị chia
+        DICT_WARD_NO_DIVIDED = DICT_PROVINCE_WARD_NO_DIVIDED.get(new_unit.province_key, {})
+        old_province_district_ward_keys = DICT_WARD_NO_DIVIDED.get(new_unit.ward_key, [])
+        
+        if old_province_district_ward_keys:
+            # Pick the first old key
+            old_province_district_ward_key = old_province_district_ward_keys[0]
+        else:
+            # 2nd attempt: Các ward cũ bị chia thành nhiều ward mới
+            # DICT_PROVINCE_WARD_DIVIDED maps: {new_province_key: {old_province_district_ward_key: [list of new ward info]}}
+            DICT_WARD_DIVIDED = DICT_PROVINCE_WARD_DIVIDED.get(new_unit.province_key, {})
+            
+            # Search for old_province_district_ward_key that contains our new_ward_key
+            for old_key, new_wards in DICT_WARD_DIVIDED.items():
+                if any(ward.get('newWardKey') == new_unit.ward_key for ward in new_wards):
+                    old_province_district_ward_key = old_key
+                    break
+            
+            # If still not found and we have street, try using location
+            if not old_province_district_ward_key and new_unit.street:
+                new_location = get_geo_location(new_unit.get_address())
+                
+                if new_location:
+                    new_point = (new_location.latitude, new_location.longitude)
+                    
+                    # Find which old ward's polygon contains this point
+                    containing_old_keys = []
+                    for old_key, new_wards in DICT_WARD_DIVIDED.items():
+                        for ward in new_wards:
+                            if ward.get('newWardKey') == new_unit.ward_key:
+                                ward_point = (ward.get('newWardLat'), ward.get('newWardLon'))
+                                is_contain = check_point_in_polygon(
+                                    point=new_point, 
+                                    polygon_center=ward_point, 
+                                    polygon_area_km2=ward.get('newWardAreaKm2', 0)
+                                )
+                                if is_contain:
+                                    containing_old_keys.append(old_key)
+                    
+                    if len(containing_old_keys) == 1:
+                        old_province_district_ward_key = containing_old_keys[0]
+                    elif containing_old_keys:
+                        # Multiple matches, pick first
+                        old_province_district_ward_key = containing_old_keys[0]
+            
+            # If still not found, try to find default
+            if not old_province_district_ward_key:
+                for old_key, new_wards in DICT_WARD_DIVIDED.items():
+                    if any(ward.get('newWardKey') == new_unit.ward_key and ward.get('isDefaultNewWard', False) for ward in new_wards):
+                        old_province_district_ward_key = old_key
+                        break
+                
+                # Last resort: pick first match
+                if not old_province_district_ward_key:
+                    for old_key, new_wards in DICT_WARD_DIVIDED.items():
+                        if any(ward.get('newWardKey') == new_unit.ward_key for ward in new_wards):
+                            old_province_district_ward_key = old_key
+                            break
+
+        # Parse old_province_district_ward_key to extract old_province_key, old_district_key and old_ward_key
+        if old_province_district_ward_key:
+            parts = old_province_district_ward_key.split('_')
+            if len(parts) >= 1:
+                old_province_key = parts[0] if parts[0] else None
+                old_district_key = parts[1] if len(parts) > 1 and parts[1] else None
+                old_ward_key = parts[2] if len(parts) > 2 and parts[2] else None
+    elif new_unit.province_key:
+        # No ward, just get province
+        old_province_keys = DICT_PROVINCE.get(new_unit.province_key, [])
+        if old_province_keys:
+            # Pick the first old province key (usually the main one)
+            old_province_key = old_province_keys[0]
+
+    # Tạo lại một địa chỉ theo 63-province format để parse lại
+    old_address_components = [i for i in (new_unit.street, old_ward_key, old_district_key, old_province_key) if i]
+    old_address = ','.join(old_address_components)
+
+    level = 3 if old_ward_key else (2 if old_district_key else 1)
+    old_unit = parse_address(old_address, mode=ParseMode.LEGACY, keep_street=True, level=level)
+    old_unit.NewAdminUnit = new_unit
+
+    return old_unit


### PR DESCRIPTION
Convert new address to old address:
```py
# Import the function
from vietnamadminunits import convert_address, convert_address_to_old

# Test with your example
old_addr = '59 nguyễn sỹ sách , p15, tan binh, hcm'
print("Original old address:", old_addr)
# Original old address: 59 nguyễn sỹ sách , p15, tan binh, hcm

# Convert old -> new
new_unit = convert_address(old_addr)
new_addr = new_unit.get_address()
print("New format:", new_addr)
# New format: 59 Nguyễn Sỹ Sách, Phường Tân Sơn, Thành phố Hồ Chí Minh

# Convert new -> old (the new function!)
old_unit = convert_address_to_old(new_addr)
old_addr_back = old_unit.get_address()
print("Back to old format:", old_addr_back)
# Back to old format: 59 Nguyễn Sỹ Sách, Phường 15, Quận Tân Bình, Thành phố Hồ Chí Minh
```